### PR TITLE
Add link text and url for each resource type

### DIFF
--- a/_capabilities/template.md
+++ b/_capabilities/template.md
@@ -17,19 +17,19 @@ tags: # Select from this set
 submission_details:
   resources: # List any resources associated with the contribution. Not all sections are required
     papers:
-      - title: Link to paper text
-        url: Link to paper url
+      - title: Paper link text
+        url: Paper link url
     software:
-      - title: Link to software text
-        url: Link to software url
-      - title: Another link to software text
-        url: Another link to software url
+      - title: Software link text
+        url: Software link url
+      - title: Another software link text
+        url: Another software link url
     demos:
-      - title: Link to demo text
-        url: Link to demo url
+      - title: Demo link text
+        url: Demo link url
     data:
-      - title: Link to data text
-        url: Link to data url
+      - title: Data link text
+        url: Data link url
    
   # Optional information describing artifact. Leave blank if unused
   version: Version Number

--- a/_capabilities/template.md
+++ b/_capabilities/template.md
@@ -17,14 +17,19 @@ tags: # Select from this set
 submission_details:
   resources: # List any resources associated with the contribution. Not all sections are required
     papers:
-      - Link to paper
+      - title: Link to paper text
+        url: Link to paper url
     software:
-      - Link to software
-      - Another link to software
+      - title: Link to software text
+        url: Link to software url
+      - title: Another link to software text
+        url: Another link to software url
     demos:
-      - Link to demo
+      - title: Link to demo text
+        url: Link to demo url
     data:
-      - Link to data
+      - title: Link to data text
+        url: Link to data url
    
   # Optional information describing artifact. Leave blank if unused
   version: Version Number

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -35,8 +35,8 @@
     {% for resource in page.submission_details.resources %}
       <h3>{{ resource[0] | capitalize }}</h3>
       <ul>
-      {% for url in resource[1] %}
-        <li><a href="{{ url }}">{{ url }}</a></li>
+      {% for child in resource[1] %}
+        <li><a href="{{ child.url }}">{% if child.title %}{{ child.title }}{% else %}{{ child.url }}{% endif %}</a></li>
       {% endfor %}
       </ul>
     {% endfor %}

--- a/_pages/contribute.md
+++ b/_pages/contribute.md
@@ -40,14 +40,19 @@ classes: wide2
    submission_details:
      resources: # List any resources associated with the contribution. Not all sections are required
        papers:
-         - Link to paper
+         - title: Link to paper text
+           url: Link to paper url
        software:
-         - Link to software
-         - Another link to software
+         - title: Link to software text
+           url: Link to software url
+         - title: Another link to software text
+           url: Another link to software url
        demos:
-         - Link to demo
+         - title: Link to demo text
+           url: Link to demo url
        data:
-         - Link to data
+         - title: Link to data text
+           url: Link to data url
    
      # Optional information describing artifact. Leave blank if unused
      version: Version Number

--- a/_pages/contribute.md
+++ b/_pages/contribute.md
@@ -40,19 +40,19 @@ classes: wide2
    submission_details:
      resources: # List any resources associated with the contribution. Not all sections are required
        papers:
-         - title: Link to paper text
-           url: Link to paper url
+         - title: Paper link text
+           url: Paper link url
        software:
-         - title: Link to software text
-           url: Link to software url
-         - title: Another link to software text
-           url: Another link to software url
+         - title: Software link text
+           url: Software link url
+         - title: Another software link text
+           url: Another software link url
        demos:
-         - title: Link to demo text
-           url: Link to demo url
+         - title: Demo link text
+           url: Demo link url
        data:
-         - title: Link to data text
-           url: Link to data url
+         - title: Data link text
+           url: Data link url
    
      # Optional information describing artifact. Leave blank if unused
      version: Version Number


### PR DESCRIPTION
Add ability to use text instead of raw url when rendering links in sidebar for each contribution.