### PR TITLE
Add IHMC technical reports

### DIFF
--- a/_capabilities/curiosity-checklist.md
+++ b/_capabilities/curiosity-checklist.md
@@ -10,6 +10,8 @@ submission_details:
     papers:
       - title: Curiosity Checklist
         url: https://data.kitware.com/api/v1/item/60abdebe2fa25629b99af6ff/download?contentDisposition=inline
+      - title: Metrics for Explainable AI
+        url: https://data.kitware.com/api/v1/item/617af06c2fa25629b9c86bbb/download?contentDisposition=inline
    
   # Optional information describing artifact
   version: 1.0

--- a/_capabilities/explanation-scorecard.md
+++ b/_capabilities/explanation-scorecard.md
@@ -8,10 +8,10 @@ submission_details:
   resources: # List any resources associated with the contribution. Not all sections are required
     papers:
       - title: Explanation Scorecard
-        url: https://data.kitware.com/api/v1/item/60a468792fa25629b95ad3bb/download?contentDisposition=inline
+        url: https://data.kitware.com/api/v1/item/617af0742fa25629b9c86c40/download?contentDisposition=inline
    
   # Optional information describing artifact
-  version: 1.0
+  version: 2.0
   size:
   license:
    

--- a/_capabilities/goodness-checklist.md
+++ b/_capabilities/goodness-checklist.md
@@ -10,6 +10,8 @@ submission_details:
     papers:
       - title: Goodness Checklist
         url: https://data.kitware.com/api/v1/item/60abdf272fa25629b99af745/download?contentDisposition=inline
+      - title: Metrics for Explainable AI
+        url: https://data.kitware.com/api/v1/item/617af06c2fa25629b9c86bbb/download?contentDisposition=inline
    
   # Optional information describing artifact
   version: 1.0

--- a/_capabilities/psychological-models-explanatory-reasoning.md
+++ b/_capabilities/psychological-models-explanatory-reasoning.md
@@ -1,0 +1,71 @@
+---
+title: "Psychological Models of Explanatory Reasoning"
+excerpt: "Technical reports from Task Area 2 of the DARPA XAI program."
+tags: # Select from this set
+  - Methodology
+  - Metrics
+  - Explanation Framework
+   
+submission_details:
+  resources: # List any resources associated with the contribution. Not all sections are required
+    papers:
+    software:
+    demos:
+    data:
+   
+  # Optional information describing artifact. Leave blank if unused
+  version: 1.0
+  size: 
+  license: 
+   
+  authors:
+    - Robert R. Hoffman
+  organizations:
+    - Institute for Human and Machine Cognition
+  point_of_contact:
+    name: Robert R. Hoffman
+    email: rhoffman@ihmc.us
+---
+   
+This contribution contains a set of technical reports on psychological models of explanation, capturing different concepts, methods, and metrics.
+
+## Overview and Blogs
+[The XAI Literature Review](https://data.kitware.com/api/v1/item/617af0622fa25629b9c86b26/download?contentDisposition=inline)  
+[Non-Algorithmic Methods for XAI](https://data.kitware.com/api/v1/item/617af0702fa25629b9c86c02/download?contentDisposition=inline)  
+[Lessons for XAI from Intelligent Tutoring Systems](https://data.kitware.com/api/v1/item/617af0612fa25629b9c86b17/download?contentDisposition=inline)  
+[The AIQ Toolkit](https://data.kitware.com/api/v1/item/617af0552fa25629b9c86a3b/download?contentDisposition=inline)  
+[The Discovery Platform](https://data.kitware.com/api/v1/item/617af0562fa25629b9c86a4b/download?contentDisposition=inline)  
+["Eggsplaining" AI: An Analogy for How Deep Nets Work](https://data.kitware.com/api/v1/item/617af0572fa25629b9c86a57/download?contentDisposition=inline)
+
+## Actionable Concepts, Methods, and Metrics for Explanatory Reasoning
+### Validated scales for Explanation Goodness, Curiosity, and Trust
+[Metrics for Explainable AI](https://data.kitware.com/api/v1/item/617af06c2fa25629b9c86bbb/download?contentDisposition=inline)  
+    For explanation goodness, satisfaction and curiosity. Includes a review of methods for evaluating user mental models.  
+[The Self-Explanation Scorecard ](https://data.kitware.com/api/v1/item/617af0742fa25629b9c86c40/download?contentDisposition=inline)  
+    For evaluating the "explanatory depth" of explanations.  
+[The Stakeholder Playbook](https://data.kitware.com/api/v1/item/617af0752fa25629b9c86c5f/download?contentDisposition=inline)  
+    For tailoring explanations to stakeholder groups.  
+[Measuring Trust in the XAI Context](https://data.kitware.com/api/v1/item/617af0662fa25629b9c86b4c/download?contentDisposition=inline)  
+
+### Methodology for eliciting user mental models
+[The Mental Models Matrix](https://data.kitware.com/api/v1/item/617af0672fa25629b9c86b66/download?contentDisposition=inline)
+
+### Methodology for creating "Cognitive Tutorials" for explaining AI systems
+[Cognitive Tutorial Authoring Guide](https://data.kitware.com/api/v1/item/617af0572fa25629b9c86a69/download?contentDisposition=inline)
+
+### Guidance for experimental design for XAI evaluation
+[Methodology Requirements](https://data.kitware.com/api/v1/item/617af06a2fa25629b9c86b9f/download?contentDisposition=inline)  
+[Methodology Recommendations](https://data.kitware.com/api/v1/item/617af0682fa25629b9c86b77/download?contentDisposition=inline)
+
+### Developing psychologically plausible models of explanation
+[Modeling the Explanation Process](https://data.kitware.com/api/v1/item/617af06d2fa25629b9c86bcd/download?contentDisposition=inline)  
+[The "Plausibility Gap" Model](https://data.kitware.com/api/v1/item/617af0712fa25629b9c86c11/download?contentDisposition=inline)
+
+### A Computational Cognitive Model of explanatory reasoning
+[Computational Cognitive Model](https://data.kitware.com/api/v1/item/617af05c2fa25629b9c86ab9/download?contentDisposition=inline)
+
+### A system for enabling users to share and discuss their own explanations
+[CXAI: Collaborative Explainable AI](https://data.kitware.com/api/v1/item/617af05d2fa25629b9c86acd/download?contentDisposition=inline)
+
+### A system for enabling developers to explore their systems: identify patterns, discover rules, find anomalies
+[The Discovery Platform](https://data.kitware.com/api/v1/item/617af0602fa25629b9c86afc/download?contentDisposition=inline)

--- a/_capabilities/satisfaction-scale.md
+++ b/_capabilities/satisfaction-scale.md
@@ -10,6 +10,8 @@ submission_details:
     papers:
       - title: Satisfaction Scale
         url: https://data.kitware.com/api/v1/item/60abdf332fa25629b99af755/download?contentDisposition=inline
+      - title: Metrics for Explainable AI
+        url: https://data.kitware.com/api/v1/item/617af06c2fa25629b9c86bbb/download?contentDisposition=inline
    
   # Optional information describing artifact
   version: 1.0

--- a/_capabilities/stakeholder-playbook.md
+++ b/_capabilities/stakeholder-playbook.md
@@ -8,10 +8,10 @@ submission_details:
   resources: # List any resources associated with the contribution. Not all sections are required
     papers:
       - title: Stakeholder Playbook
-        url: https://data.kitware.com/api/v1/item/60a468842fa25629b95ad3d4/download?contentDisposition=inline
+        url: https://data.kitware.com/api/v1/item/617af0752fa25629b9c86c5f/download?contentDisposition=inline
    
   # Optional information describing artifact
-  version: 1.0
+  version: 2.0
   size:
   license:
    
@@ -19,6 +19,8 @@ submission_details:
     - Robert R. Hoffman<sup>1</sup>
     - Gary Klein<sup>2</sup>
     - Shane T. Mueller<sup>3</sup>
+    - Mohammadreza Jalaeian<sup>2</sup>
+    - Connor Tate<sup>1</sup>
   organizations:
     - 1. Institute for Human and Machine Cognition
     - 2. Macrocognition, LLC


### PR DESCRIPTION
Update existing IHMC contributions with new resource versions and add additional overview and links of TA2 technical reports.